### PR TITLE
Baseline shadow

### DIFF
--- a/pyexsmt/constraint.py
+++ b/pyexsmt/constraint.py
@@ -100,8 +100,9 @@ def solve_constraint_function(constraint):
 
 def submit_constraint_sovling(constraint, slover="z3"):
     # create the solver and assign constraint solving to a different thread
-    constraint.solver= Solver(slover)
-    constraint.solving_thread = Thread(target=solve_constraint_function, args={constraint})
-    constraint.solving_thread.start()
+    if constraint.solving_thread is not None:
+        constraint.solver= Solver(slover)
+        constraint.solving_thread = Thread(target=solve_constraint_function, args={constraint})
+        constraint.solving_thread.start()
 
 

--- a/pyexsmt/constraint.py
+++ b/pyexsmt/constraint.py
@@ -103,7 +103,7 @@ def solve_constraint_function(constraint):
 
 def submit_constraint_sovling(constraint, slover="z3"):
     # create the solver and assign constraint solving to a different thread
-    if constraint.solving_thread is None:
+    if not constraint.processed and constraint.solving_thread is None:
         constraint.solver= Solver(slover)
         constraint.solving_thread = Thread(target=solve_constraint_function, args={constraint})
         constraint.solving_thread.start()

--- a/pyexsmt/constraint.py
+++ b/pyexsmt/constraint.py
@@ -89,14 +89,8 @@ class Constraint:
         return hash(id(self))
 
 def solve_constraint_function(constraint):
-    # only allow 1 constraint to be solved at 1 time
-    Constraint.Constraint_Solving_lock.acquire()
-    try:
-        constraint.solveConstraint()
-    except:
-        raise
-    finally:
-        Constraint.Constraint_Solving_lock.release()
+    constraint.solveConstraint()
+
 
 def submit_constraint_sovling(constraint, slover="z3"):
     # create the solver and assign constraint solving to a different thread

--- a/pyexsmt/path_to_constraint.py
+++ b/pyexsmt/path_to_constraint.py
@@ -8,7 +8,7 @@ from collections import deque
 from pyexsmt.symbolic_types.symbolic_object import to_pysmt, is_instance_userdefined_and_newclass
 from pyexsmt import pred_to_smt, get_concr_value, match_smt_type
 from pyexsmt.symbolic_types import SymbolicObject
-from pyexsmt.constraint import Constraint
+from pyexsmt.constraint import Constraint, submit_constraint_sovling
 from pyexsmt.predicate import Predicate
 
 from pysmt.shortcuts import *
@@ -98,6 +98,8 @@ class PathToConstraint:
             c.processed = True
             logging.info("Processed constraint: %s", c)
 
+        # submit a job to solve constraint
+        submit_constraint_sovling(c)
         self.current_constraint = c
 
     def add_constraint(self, c):
@@ -112,11 +114,20 @@ class PathToConstraint:
     def solve_constraint(self, selected):
         #TODO Check if we already have a solution to it first
         #TODO Do local search if we have an almost solution?
-        asserts, query = selected.get_asserts_and_query()
-        assumptions = [self.mod] + [pred_to_smt(p) for p in asserts] + [Not(pred_to_smt(query))]
-        self.solver.solve(assumptions)
-        logging.debug("SOLVING: %s", assumptions)
-        return self.solver.last_result
+        if selected.solving_thread is not None:
+            # if job for solving constraint has already started, wait for the result
+            selected.solving_thread.join()
+            self.solver = selected.solver
+            SymbolicObject.SOLVER = self.solver
+            selected.processed = True
+            selected.solver = None
+            return self.solver.last_result
+        else:
+            asserts, query = selected.get_asserts_and_query()
+            assumptions = [self.mod] + [pred_to_smt(p) for p in asserts] + [Not(pred_to_smt(query))]
+            self.solver.solve(assumptions)
+            logging.debug("SOLVING: %s", assumptions)
+            return self.solver.last_result
 
     def record_inputs(self, inputs):
         inputs = [(k, get_concr_value(inputs[k])) for k in inputs]

--- a/pyexsmt/path_to_constraint.py
+++ b/pyexsmt/path_to_constraint.py
@@ -120,13 +120,16 @@ class PathToConstraint:
             self.solver = selected.solver
             SymbolicObject.SOLVER = self.solver
             selected.processed = True
+            # free the memory occupied by the solver and solving thread
             selected.solver = None
+            selected.solving_thread = None
             return self.solver.last_result
         else:
             asserts, query = selected.get_asserts_and_query()
             assumptions = [self.mod] + [pred_to_smt(p) for p in asserts] + [Not(pred_to_smt(query))]
             self.solver.solve(assumptions)
             logging.debug("SOLVING: %s", assumptions)
+            selected.processed = True
             return self.solver.last_result
 
     def record_inputs(self, inputs):

--- a/pyexsmt/path_to_constraint.py
+++ b/pyexsmt/path_to_constraint.py
@@ -66,10 +66,17 @@ class PathToConstraint:
         c = self.current_constraint.find_child(p)
 
         if c is None:
-            asserts = [pred_to_smt(p) for p in self.current_constraint.get_asserts()]
-            if self.mod is not None and not is_sat(And(self.mod, pred_to_smt(p), *asserts)):
-                logging.debug("Path pruned by mod (%s): %s %s", self.mod, c, p)
-                return
+            if self.mod is not None:
+                asserts = [pred_to_smt(p) for p in self.current_constraint.get_asserts()]
+                Constraint.Constraint_Solving_lock.acquire()
+                try:
+                    if not is_sat(And(self.mod, pred_to_smt(p), *asserts)):
+                        logging.debug("Path pruned by mod (%s): %s %s", self.mod, c, p)
+                        return
+                except:
+                    raise
+                finally:
+                    Constraint.Constraint_Solving_lock.release()
 
             c = self.current_constraint.add_child(p)
 


### PR DESCRIPTION
One set-back from the original symbolic search engine is that the constraint solving task only occurs at the end of program exploration (when the engine needs an different input to explore an alternative path).  we realized that the constraint solving can be parallelized from program exploration as they do not conflict.   

Goal:  Whenever the search engine discovers a branch point and take one direction with its path constraint, the constraint will be queued for SMT solving immediately. The actual solving task is performed in a background worker thread so that it does not block the program exploration. After the engine finishes the current execution and queries for the next input, the solved constraint will provide the input value that leads to a different program path. 